### PR TITLE
/fc in Beamtenfahrzeugen

### DIFF
--- a/terratex_reallife/ENVIRO/chat.lua
+++ b/terratex_reallife/ENVIRO/chat.lua
@@ -265,7 +265,7 @@ addCommandHandler("t", t_func, false, false)
 function flug_chat(thePlayer, cmd, text, ...)
     if (isPedInVehicle(thePlayer)) then
         local veh = getPedOccupiedVehicle(thePlayer)
-        if ((isPlane(veh) or isHeli(veh)) and (getPedOccupiedVehicleSeat(thePlayer) == 0)) then
+        if (((isPlane(veh) or isHeli(veh)) and (getPedOccupiedVehicleSeat(thePlayer) == 0)) or (isPoliceCar(veh) and vioGetElementData(thePlayer, "fcc"))) then
             if (text) then
                 text = text .. " " .. table.concat({ ... }, " ")
                 chat_log(thePlayer, "(flugchat) " .. text)
@@ -280,7 +280,7 @@ function sendFlugChatMessage(name, message)
     for theKey, thePerson in ipairs(getElementsByType("player")) do
         if (isPedInVehicle(thePerson)) then
             local veh = getPedOccupiedVehicle(thePerson)
-            if ((isPlane(veh) or isHeli(veh)) and (getPedOccupiedVehicleSeat(thePerson) == 0)) then
+            if (((isPlane(veh) or isHeli(veh)) and (getPedOccupiedVehicleSeat(thePerson) == 0)) or (isPoliceCar(veh) and vioGetElementData(thePerson, "fcc"))) then
                 outputChatBox(string.format("Flugchat (/fc) %s: %s", name, message), thePerson, 244, 0, 252)
             end
         end

--- a/terratex_reallife/ENVIRO/fraktionen/lspd/arrest.lua
+++ b/terratex_reallife/ENVIRO/fraktionen/lspd/arrest.lua
@@ -1004,3 +1004,16 @@ function sos_func(thePlayer)
     end
 end
 addCommandHandler("sos", sos_func, false, false)
+
+function fcc_func(thePlayer)
+    if (isBeamter(thePlayer)) then
+        if(not (vioGetElementData(thePlayer, "fcc"))) then
+			vioSetElementData(thePlayer, "fcc", true)
+			showError(thePlayer,"Du kannst nun den /fc in Beamtenfahrzeugen nutzen.")
+		else
+			vioSetElementData(thePlayer, "fcc", false)
+			showError(thePlayer,"Du kannst nun den /fc in Beamtenfahrzeugen nicht mehr nutzen.")
+		end
+    end
+end
+addCommandHandler("fcc", fcc_func, false, false)

--- a/terratex_reallife/USER/userdata/player_connect.lua
+++ b/terratex_reallife/USER/userdata/player_connect.lua
@@ -597,6 +597,7 @@ function LoginPlayerData(nickname, pw)
         sendalkacolshape_func(source)
 
         triggerClientEvent(source, "showHud", source, true);
+		vioSetElementData(source, "fcc", false)
     else
         local logversuche = tonumber(vioGetElementData(source, "logtries"))
         logversuche = logversuche + 1


### PR DESCRIPTION
Durch die Änderungen wird es möglich, dass Beamten in Beamtenfahrzeugen mit /fcc den Flugchat einsehen und nutzen können.

Dies währe für Flugkontrollen sehr hilfreich.