### PR TITLE
Medic-Todes-Anzeige als Error-Box

### DIFF
--- a/terratex_reallife/ENVIRO/spawn_kill_system/kill.lua
+++ b/terratex_reallife/ENVIRO/spawn_kill_system/kill.lua
@@ -77,6 +77,7 @@ function death_func(ammo, attacker, weapon, bodypart)
         for theKey, thePerson in ipairs(getPlayersInTeam(team[10])) do
             if (vioGetElementData(thePerson, "isShowingMedicDeathBlip")) then
                 setElementVisibleTo(mechaBlip, thePerson, true)
+                showError(thePerson, "Jemand ist gestorben!")
             end
         end
         vioSetElementData(source, "isDeathPlayerBlip", mechaBlip)


### PR DESCRIPTION
Damit bei den Medic-Todes-Anzeigen auch die Error-Box eingeblendet (und ein Ton abgespielt) wird.