### PR TITLE
Boot(/Flugzeug) +1000$ für nicht notwendige Reparatur beim Tanken

### DIFF
--- a/terratex_reallife/SYSTEM/vehsys/tankstelle.lua
+++ b/terratex_reallife/SYSTEM/vehsys/tankstelle.lua
@@ -121,10 +121,12 @@ function setTankFulTanke(preis, hitElement, driver, marker, liter)
     if (isElement(hitElement)) then
         vioSetElementData(hitElement, "isInTankProcedur", false)
         vioSetElementData(hitElement, "tank", 100)
-        if (vioGetElementData(marker, "repairMarker")) then
+        if (vioGetElementData(marker, "repairMarker") and getElementHealth(hitElement) < 950) then
             preis = preis + 1000
             outputChatBox("Das Fahrzeug wurde repariert!", driver, 255, 0, 0)
             fixVehicle(hitElement)
+        else
+            outputChatBox("Da das Fahrzeug in einem sehr guten Zustand ist, wurde es nicht repariert!", driver, 255, 0, 0)
         end
         changePlayerMoney(driver, -preis, "fahrzeug", "Tanken")
         changeBizKasse(7, preis, "Tank")


### PR DESCRIPTION
Boot(/Flugzeug) tanken kostet +1000$, obwohl das Fahrzeug in einem 100%-Zustand ist