### PR TITLE
Zonen, in denen Occlusion ausgeschaltet wird

### DIFF
--- a/terratex_reallife/ENGINE/mapFileAdditions/mapEditorScriptingExtension_s.lua
+++ b/terratex_reallife/ENGINE/mapFileAdditions/mapEditorScriptingExtension_s.lua
@@ -40,8 +40,6 @@ function onMapReload()
 end
 
 function onMapResourceStartOrStop()
-
-    setOcclusionsEnabled(false)
     for _, object in ipairs(getElementsByType("removeWorldObject", source)) do
         local model = getElementData(object, "model")
         local lodModel = getElementData(object, "lodModel")

--- a/terratex_reallife/ENGINE/mapFileAdditions/noOcclusionZones_client.lua
+++ b/terratex_reallife/ENGINE/mapFileAdditions/noOcclusionZones_client.lua
@@ -1,0 +1,32 @@
+local zones = {
+    {x = 2695.24, y = -2649.56, radius = 280, dimension = 0, interior = 0} --Atomkraftwerk
+}
+
+function createZones()
+    for key,value in pairs(zones) do
+        zones[key].colCircle = createColCircle(zones[key].x, zones[key].y, zones[key].radius)
+    end
+    addEventHandler("onClientElementColShapeHit", getLocalPlayer(), enterZone)
+    addEventHandler("onClientElementColShapeLeave", getLocalPlayer(), leaveZone)
+end
+addEventHandler("onClientResourceStart", getResourceRootElement(getThisResource()), createZones)
+
+function enterZone(theShape)
+    local thePlayer = getLocalPlayer()
+    for key,value in pairs(zones) do
+        if (theShape == zones[key].colCircle and getElementDimension(thePlayer) == zones[key].dimension and getElementInterior(thePlayer) == zones[key].interior) then
+            setOcclusionsEnabled(false)
+            outputDebugString("occlusionsEnabled: false")
+        end
+    end
+end
+
+function leaveZone(theShape)
+    local thePlayer = getLocalPlayer()
+    for key,value in pairs(zones) do
+        if (theShape == zones[key].colCircle and getElementDimension(thePlayer) == zones[key].dimension and getElementInterior(thePlayer) == zones[key].interior) then
+            setOcclusionsEnabled(true)
+            outputDebugString("occlusionsEnabled: true")
+        end
+    end
+end

--- a/terratex_reallife/meta.xml
+++ b/terratex_reallife/meta.xml
@@ -472,6 +472,7 @@
     <script src="ENGINE/mapFileAdditions/mapEditorScriptingExtension_c.lua" type="client"/>
     <script src="ENGINE/mapFileAdditions/mapEditorScriptingExtension_s.lua" type="server"/>
     <script src="ENGINE/mapFileAdditions/allDimensionObject_client.lua" type="client"/>
+    <script src="ENGINE/mapFileAdditions/noOcclusionZones_client.lua" type="client"/>
     <!-- SF AIPORT -->
     <map src="MAPS/umgebung/map-sf-airport.map"/>
     <script src="MAPS/mapscripts/vorplatzwasser.lua" type="server"/>


### PR DESCRIPTION
Habe mal ein wenig rumgetestet. Funktioniert einwandfrei wenn dies beim Client nur in bestimmten Zonen deaktiviert wird. Somit performanter (vorallendingen am PD).